### PR TITLE
Configure npm authentication for GitHub Packages in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Configure npm for GitHub Packages
+        run: echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> ~/.npmrc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Publish to GitHub Packages
         run: npm publish --registry=https://npm.pkg.github.com/
         env:


### PR DESCRIPTION
Issue: Error in publishing to GitHub Packages
https://github.com/earvinpiamonte/pagasa-tcb-parser/actions/runs/16655557180/job/47139529806

Resolution: Configure auth for GitHub Packages